### PR TITLE
feat: Revise open source interests

### DIFF
--- a/src/open-source/config/open-source.json
+++ b/src/open-source/config/open-source.json
@@ -1,31 +1,31 @@
 {
 	"terms":  {
-		"Open Source Focus": {
-			"Open Source Sharing": [
-				"Licensing",
-				"Intellectual Property",
-				"Documentation",
-				"Citation",
-				"Metadata"
-			],
-			"Open Source Software": [
+		"Open Source": {
+			"Software": [
 				"Software Development",
 				"Software Storage",
 				"Software Packages",
 				"Software Versioning",
 				"Software Publication"
 			],
-			"Open Source Hardware": [
+			"Hardware": [
 				"Hardware Design",
 				"Hardware Description Language"
 			],
-			"Open Source Community": [
+			"Maintainership": [
+				"Licensing",
+				"Intellectual Property",
+				"Documentation",
+				"Citation",
+				"Metadata"
+			],
+			"Community": [
 				"Project Management",
 				"Contribution Mechanism",
 				"Community Development",
 				"Training and Education"
 			],
-			"Open Source Culture": [
+			"Practices": [
 				"FAIR Principles",
 				"CARE Principles",
 				"Data visualization",


### PR DESCRIPTION
This is in the context of the https://maps.datascience.wisc.edu/open-source/

* Remove repeated use of 'open source' in subtopics/subinterests to avoid overuse, as the lists are short enough to all still be visbly under "Open Source".
* Rename 'Open Source Sharing' to 'Maintainership' as the topics listed are ones that generally full under the responsibility of project maintainers to steer and be responsible for. Some, but not all, of these topics are also usually categorized as 'governance' issues.
* Rename 'Open Source Culture' to 'Practices' as project 'culture' is usually more focused on the mechanics of community/contributor and maintainer interactions and the interactions of the broader community. 'Practices' places more of an emphasis on how projects implement different aspects of the broader concept of 'open source'.

Note that this is only focusing on the open source terms, as the others are found across multiple different maps and so this PR is just for those specific to the open source map.